### PR TITLE
Switch to safe yaml loader

### DIFF
--- a/asym_crypto_yaml/crypto.py
+++ b/asym_crypto_yaml/crypto.py
@@ -277,6 +277,6 @@ def decrypt_yaml_file_and_write_encrypted_file_to_disk(input_yaml_file_path, pri
     if private_key_path is not None:
         private_key = load_private_key_from_file(private_key_path)
     with open(input_yaml_file_path, "r") as f:
-        encrypted_secrets = yaml.load(f)
+        encrypted_secrets = yaml.safe_load(f)
     decrypted_secrets_dict = decrypt_yaml_dict(encrypted_secrets, private_key)
     write_dict_to_yaml(decrypted_secrets_dict, output_yaml_file_path)

--- a/setup.py
+++ b/setup.py
@@ -15,7 +15,7 @@ with open(path.join(here, 'README.rst'), encoding='utf-8') as f:
 
 setup(
     name='asym_crypto_yaml',  # Required
-    version='0.0.5',  # Required
+    version='0.0.6',  # Required
     packages=find_packages(exclude=['contrib', 'docs', 'tests']),  # Required
     python_requires=">=3.6",
     include_package_data=True,


### PR DESCRIPTION
Hermes has been getting the following warning. I figured I'd check this code too. The rest of this file uses safe_load. Is there a reason this line didn't that I'm not aware of?

```/edx/app/hermes/hermes/hermes.py:45: YAMLLoadWarning: calling yaml.load() without Loader=... is deprecated, as the default Loader is unsafe. Please read https://msg.pyyaml.org/load for full details.```