### PR TITLE
Separating test envs in Travis

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,6 +1,15 @@
 language: python
+matrix:
+  include:
+    - python: 3.6
+      env: TOXENV=py36
+    - python: 3.8
+      env: TOXENV=py38
+
+install:
+  - "pip install -r requirements/development.txt"
 script:
-- make test
+- tox -e $TOXENV
 services:
 - docker
 deploy:

--- a/.travis.yml
+++ b/.travis.yml
@@ -5,7 +5,6 @@ matrix:
       env: TOXENV=py36
     - python: 3.8
       env: TOXENV=py38
-
 install:
   - "pip install -r requirements/development.txt"
 script:

--- a/Makefile
+++ b/Makefile
@@ -6,22 +6,17 @@ help: ## Display this help message
 	@echo "Please use \`make <target>' where <target> is one of"
 	@perl -nle'print $& if m{^[\.a-zA-Z_-]+:.*?## .*$$}' $(MAKEFILE_LIST) | sort | awk 'BEGIN {FS = ":.*?## "}; {printf "\033[36m  %-25s\033[0m %s\n", $$1, $$2}'
 
-build-docker:
-	docker build -t edxops/asym-crypto-yaml .
+requirements:
+	pip install -qr requirements/development.txt
 
-upgrade: build-docker ## update the pip requirements files to use the latest releases satisfying our constraints
-	docker run -it --rm -v $(pwd):/app edxops/asym-crypto-yaml make upgrade-requirements
-
-upgrade-requirements: export CUSTOM_COMPILE_COMMAND=make upgrade
-upgrade-requirements: ## update the pip requirements files to use the latest releases satisfying our constraints, outside of docker
+upgrade: export CUSTOM_COMPILE_COMMAND=make upgrade
+upgrade: ## update the pip requirements files to use the latest releases satisfying our constraints
+	pip install -q -r requirements/pip-tools.txt
 	pip-compile --upgrade -o requirements/pip-tools.txt requirements/pip-tools.in
 	pip-compile --upgrade -o requirements/requirements.txt requirements/requirements.in
 	pip-compile --upgrade -o requirements/development.txt requirements/development.in
 
-test: build-docker  ## Run tests
-	docker run -it --rm edxops/asym-crypto-yaml make run-tests
-
-run-tests: ## Run tests
+test: ## Run tests using tox
 	tox
 
 shell: ## Open a shell in the docker container

--- a/requirements/development.txt
+++ b/requirements/development.txt
@@ -14,19 +14,19 @@ filelock==3.0.12          # via tox, virtualenv
 importlib-metadata==1.6.0  # via importlib-resources, pluggy, pytest, tox, virtualenv
 importlib-resources==1.5.0  # via virtualenv
 more-itertools==8.3.0     # via pytest
-packaging==20.3           # via pytest, tox
-pip-tools==5.1.2          # via -r requirements/pip-tools.txt
+packaging==20.4           # via pytest, tox
+pip-tools==5.2.0          # via -r requirements/pip-tools.txt
 pluggy==0.13.1            # via pytest, tox
 py==1.8.1                 # via pytest, tox
 pycparser==2.20           # via -r requirements/requirements.txt, cffi
 pyparsing==2.4.7          # via packaging
-pytest==5.4.2             # via -r requirements/development.in
+pytest==5.4.3             # via -r requirements/development.in
 pyyaml==5.3.1             # via -r requirements/requirements.txt
-six==1.14.0               # via -r requirements/pip-tools.txt, -r requirements/requirements.txt, cryptography, packaging, pip-tools, tox, virtualenv
+six==1.15.0               # via -r requirements/pip-tools.txt, -r requirements/requirements.txt, cryptography, packaging, pip-tools, tox, virtualenv
 toml==0.10.1              # via tox
-tox==3.15.0               # via -r requirements/development.in
-virtualenv==20.0.20       # via tox
-wcwidth==0.1.9            # via pytest
+tox==3.15.1               # via -r requirements/development.in
+virtualenv==20.0.21       # via tox
+wcwidth==0.2.3            # via pytest
 zipp==3.1.0               # via importlib-metadata, importlib-resources
 
 # The following packages are considered to be unsafe in a requirements file:

--- a/requirements/pip-tools.txt
+++ b/requirements/pip-tools.txt
@@ -5,8 +5,8 @@
 #    make upgrade
 #
 click==7.1.2              # via pip-tools
-pip-tools==5.1.2          # via -r requirements/pip-tools.in
-six==1.14.0               # via pip-tools
+pip-tools==5.2.0          # via -r requirements/pip-tools.in
+six==1.15.0               # via pip-tools
 
 # The following packages are considered to be unsafe in a requirements file:
 # pip

--- a/requirements/requirements.txt
+++ b/requirements/requirements.txt
@@ -9,4 +9,4 @@ click==7.1.2              # via -r requirements/requirements.in
 cryptography==2.9.2       # via -r requirements/requirements.in
 pycparser==2.20           # via cffi
 pyyaml==5.3.1             # via -r requirements/requirements.in
-six==1.14.0               # via cryptography
+six==1.15.0               # via cryptography


### PR DESCRIPTION
**Issue:** [BOM-1683](https://openedx.atlassian.net/browse/BOM-1683)

### Description
- Separated py36 and py38 test environments in Travis.
- Updated MakeFile to use tox for running tests.