### PR TITLE
fix: install pip and pip-tools after upgrading

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -15,6 +15,8 @@ upgrade: ## update the pip requirements files to use the latest releases satisfy
 	pip install -q -r requirements/pip-tools.txt
 	pip-compile --allow-unsafe --rebuild -o requirements/pip.txt requirements/pip.in
 	pip-compile --upgrade -o requirements/pip-tools.txt requirements/pip-tools.in
+	pip install -qr requirements/pip.txt
+	pip install -qr requirements/pip-tools.txt
 	pip-compile --upgrade -o requirements/base.txt requirements/base.in
 	pip-compile --upgrade -o requirements/development.txt requirements/development.in
 


### PR DESCRIPTION
Updated the upgrade target script to check the compatibility of upgraded pip and pip-tools versions.
For reference, look at this [PR](https://github.com/openedx/edx-repo-health/pull/271) for new check added in edx-repo-health. 
JIRA: https://2u-internal.atlassian.net/browse/BOM-3425